### PR TITLE
refactor: profile tables

### DIFF
--- a/src/components/tables/BaseTable.tsx
+++ b/src/components/tables/BaseTable.tsx
@@ -28,6 +28,7 @@ type Props = {
   };
   tableStructure: TableStructure[];
   tableHeader?: string;
+  tableHeaderComponent?: React.ReactNode;
 };
 
 const BaseTable: React.FC<Props> = ({
@@ -38,14 +39,17 @@ const BaseTable: React.FC<Props> = ({
   actionState,
   tableStructure,
   tableHeader,
+  tableHeaderComponent,
 }) => {
   return (
     <Box fontSize="sm" py={4} isolation="isolate">
-      {tableHeader && (
-        <Heading size="md" mb={6}>
-          {tableHeader}
-        </Heading>
-      )}
+      {tableHeaderComponent
+        ? tableHeaderComponent
+        : tableHeader && (
+            <Heading size="md" mb={6}>
+              {tableHeader}
+            </Heading>
+          )}
       {refetch && <RefetchButton refetch={refetch} />}
       <Table
         boxShadow="lg"

--- a/src/components/tables/CurrentJobsTable.tsx
+++ b/src/components/tables/CurrentJobsTable.tsx
@@ -1,24 +1,10 @@
-/* eslint-disable no-unused-vars */
+import useTranscripts from "@/hooks/useTranscripts";
 import { getCount } from "@/utils";
-import { Box, Heading, Table, Tbody, Thead, Tr } from "@chakra-ui/react";
-import React from "react";
-import type { Transcript } from "../../../types";
-import {
-  DataEmpty,
-  LoadingSkeleton,
-  RefetchButton,
-  RowData,
-  TableHeader,
-} from "./TableItems";
+import { Heading } from "@chakra-ui/react";
+import BaseTable from "./BaseTable";
 import type { TableStructure } from "./types";
 
-type Props = {
-  data: Transcript[];
-  isLoading: boolean;
-  refetch?: () => Promise<unknown>;
-};
-
-const tableStructure: TableStructure[] = [
+const tableStructure = [
   { name: "date", type: "date", modifier: (data) => data?.createdAt },
   {
     name: "title",
@@ -41,48 +27,29 @@ const tableStructure: TableStructure[] = [
     type: "text-short",
     modifier: (data) => `${getCount(data.originalContent.body) ?? "-"} words`,
   },
-  { name: "total bounty", type: "text-short", modifier: (_) => "N/A" },
+  { name: "total bounty", type: "text-short", modifier: () => "N/A" },
   { name: "status", type: "action", modifier: (data) => data.id },
-];
+] satisfies TableStructure[];
 
-const CurrentJobsTable: React.FC<Props> = ({ data, isLoading, refetch }) => {
-  return (
-    <Box fontSize="sm" py={4} isolation="isolate">
-      <Heading size="sm" mb={1}>
-        Current Jobs
-      </Heading>
-      {refetch && <RefetchButton refetch={refetch} />}
-      <Table boxShadow="lg" borderRadius="xl">
-        <Thead>
-          <TableHeader tableStructure={tableStructure} />
-        </Thead>
-        <Tbody fontWeight="medium">
-          {isLoading ? (
-            <LoadingSkeleton rowsLength={tableStructure.length} />
-          ) : data?.length ? (
-            data.map((dataRow) => (
-              <TableRow
-                key={`data-row-${dataRow.id}`}
-                row={dataRow}
-                ts={tableStructure}
-              />
-            ))
-          ) : (
-            <DataEmpty />
-          )}
-        </Tbody>
-      </Table>
-    </Box>
-  );
-};
+const CurrentJobsTable = () => {
+  const { transcripts } = useTranscripts();
+  const { data, isLoading, isError, refetch } = transcripts;
 
-const TableRow = ({ row, ts }: { row: Transcript; ts: TableStructure[] }) => {
   return (
-    <Tr>
-      {ts.map((tableItem) => (
-        <RowData key={tableItem.name} tableItem={tableItem} row={row} />
-      ))}
-    </Tr>
+    <>
+      <BaseTable
+        data={data ?? []}
+        isLoading={isLoading}
+        isError={isError}
+        refetch={refetch}
+        tableStructure={tableStructure}
+        tableHeaderComponent={
+          <Heading size="sm" mb={1}>
+            Current Jobs
+          </Heading>
+        }
+      />
+    </>
   );
 };
 

--- a/src/components/tables/PastJobsTable.tsx
+++ b/src/components/tables/PastJobsTable.tsx
@@ -1,24 +1,10 @@
-/* eslint-disable no-unused-vars */
+import useTranscripts from "@/hooks/useTranscripts";
 import { getCount } from "@/utils";
-import { Box, Heading, Table, Tbody, Thead, Tr } from "@chakra-ui/react";
-import React from "react";
-import type { Transcript } from "../../../types";
-import {
-  DataEmpty,
-  LoadingSkeleton,
-  RefetchButton,
-  RowData,
-  TableHeader,
-} from "./TableItems";
+import { Heading } from "@chakra-ui/react";
+import BaseTable from "./BaseTable";
 import type { TableStructure } from "./types";
 
-type Props = {
-  data: Transcript[];
-  isLoading: boolean;
-  refetch?: () => Promise<unknown>;
-};
-
-const tableStructure: TableStructure[] = [
+const tableStructure = [
   { name: "date", type: "date", modifier: (data) => data?.createdAt },
   {
     name: "title",
@@ -41,48 +27,29 @@ const tableStructure: TableStructure[] = [
     type: "text-short",
     modifier: (data) => `${getCount(data.originalContent.body) ?? "-"} words`,
   },
-  { name: "bounty rate", type: "text-short", modifier: (_) => "N/A" },
+  { name: "bounty rate", type: "text-short", modifier: () => "N/A" },
   { name: "status", type: "action", modifier: (data) => data.id },
-];
+] satisfies TableStructure[];
 
-const PastJobsTable: React.FC<Props> = ({ data, isLoading, refetch }) => {
-  return (
-    <Box fontSize="sm" py={4} isolation="isolate">
-      <Heading size="sm" mb={1}>
-        Past Jobs
-      </Heading>
-      {refetch && <RefetchButton refetch={refetch} />}
-      <Table boxShadow="lg" borderRadius="xl">
-        <Thead>
-          <TableHeader tableStructure={tableStructure} />
-        </Thead>
-        <Tbody fontWeight="medium">
-          {isLoading ? (
-            <LoadingSkeleton rowsLength={tableStructure.length} />
-          ) : data?.length ? (
-            data.map((dataRow) => (
-              <TableRow
-                key={`data-row-${dataRow.id}`}
-                row={dataRow}
-                ts={tableStructure}
-              />
-            ))
-          ) : (
-            <DataEmpty />
-          )}
-        </Tbody>
-      </Table>
-    </Box>
-  );
-};
+const PastJobsTable = () => {
+  const { transcripts } = useTranscripts();
+  const { data, isLoading, isError, refetch } = transcripts;
 
-const TableRow = ({ row, ts }: { row: Transcript; ts: TableStructure[] }) => {
   return (
-    <Tr>
-      {ts.map((tableItem) => (
-        <RowData key={tableItem.name} tableItem={tableItem} row={row} />
-      ))}
-    </Tr>
+    <>
+      <BaseTable
+        data={data ?? []}
+        isLoading={isLoading}
+        isError={isError}
+        refetch={refetch}
+        tableStructure={tableStructure}
+        tableHeaderComponent={
+          <Heading size="sm" mb={1}>
+            Past Jobs
+          </Heading>
+        }
+      />
+    </>
   );
 };
 

--- a/src/pages/[username]/index.tsx
+++ b/src/pages/[username]/index.tsx
@@ -1,27 +1,15 @@
 import CurrentJobsTable from "@/components/tables/CurrentJobsTable";
 import PastJobsTable from "@/components/tables/PastJobsTable";
-import useTranscripts from "@/hooks/useTranscripts";
 import { Heading } from "@chakra-ui/react";
 
-export default function Home() {
-  const { data, isLoading, isRefetching, refetch } =
-    useTranscripts().transcripts;
-
+export default function Profile() {
   return (
     <>
       <Heading size="md" mb={6}>
         My Account
       </Heading>
-      <CurrentJobsTable
-        data={data ?? []}
-        isLoading={isLoading || isRefetching}
-        refetch={refetch}
-      />
-      <PastJobsTable
-        data={data ?? []}
-        isLoading={isLoading || isRefetching}
-        refetch={refetch}
-      />
+      <CurrentJobsTable />
+      <PastJobsTable />
     </>
   );
 }


### PR DESCRIPTION
Refactor the `Current jobs` and `Past jobs` tables to use the same base table as the `Queue table` used on the home page.