### PR TITLE
Keep active claim button, redirect unauthed users to login

### DIFF
--- a/src/components/tables/QueueTable.tsx
+++ b/src/components/tables/QueueTable.tsx
@@ -125,8 +125,8 @@ const QueueTable = () => {
       if (status === "loading") {
         toast({
           status: "loading",
-          title: "Authenticating....",
-          description: "Authenticating.... please wait.",
+          title: "loading fun",
+          description: "loading up some fun for you... please wait.",
         });
         return;
       } else if (status === "unauthenticated") {

--- a/src/components/tables/QueueTable.tsx
+++ b/src/components/tables/QueueTable.tsx
@@ -130,10 +130,9 @@ const QueueTable = () => {
         });
         return;
       } else if (status === "unauthenticated") {
-        toast({
-          status: "warning",
-          title: "Unauthenticated",
-          description: "You have to login to claim a transcript",
+        // Sign-in user before trying to claim a transcript
+        await signIn("github", {
+          callbackUrl: `/?reclaim=true&txId=${transcriptId}`,
         });
         return;
       }
@@ -228,8 +227,6 @@ const QueueTable = () => {
         {
           name: "Up for grabs",
           actionName: "claim",
-          isDisabled: !canClaimTranscript,
-          isDisabledText: "You must be loggedIn and have no active reviews",
           type: "action",
           modifier: (data) => data.id,
           action: (data: Transcript) => handleClaim(data.id),

--- a/src/pages/reviews/[id].tsx
+++ b/src/pages/reviews/[id].tsx
@@ -16,7 +16,7 @@ const TranscriptPage = () => {
   const { data: review, status: reviewStatus, error } = useReview(Number(id));
 
   if (status === "loading" || reviewStatus === "loading") {
-    return <AuthStatus title="Authenticating" message="Please wait" />;
+    return <AuthStatus title="Loading up some fun... " message="Please wait" />;
   }
   if (status === "unauthenticated" || !sessionData?.user?.id) {
     return <RedirectToLogin />;


### PR DESCRIPTION
closes https://github.com/bitcointranscripts/transcription-review-front-end/issues/90 and closes https://github.com/bitcointranscripts/transcription-review-front-end/issues/76