### PR TITLE
chore: update account creation logic for backend migration

### DIFF
--- a/src/services/api/endpoints.ts
+++ b/src/services/api/endpoints.ts
@@ -29,6 +29,8 @@ const GET_TRANSCRIPTS_BY_ID = (id: number) => `transcripts/${id}`;
 
 const USERS = () => `users`;
 
+const USER_BY_ID = (id: number) => `users/${id}`;
+
 const USER_REVIEWS = (id: number) => `users/${id}/reviews`;
 
 const REVIEWS = ({ userId, username, status }: ReviewQueryOptions) => {
@@ -45,6 +47,7 @@ const endpoints = {
   GET_TRANSCRIPTS,
   GET_TRANSCRIPTS_BY_ID,
   USERS,
+  USER_BY_ID,
   USER_REVIEWS,
   REVIEWS,
   REVIEW_BY_ID,

--- a/src/services/api/lib.ts
+++ b/src/services/api/lib.ts
@@ -1,19 +1,22 @@
 import axios from "./axios";
 import endpoints from "./endpoints";
 
-type CreateUserProp = {
+export type CreateUserProp = {
   username: string;
   permissions?: string;
+  email: string;
 };
 
 type UserData = {
   data: {
     permissions: "reviewer" | "admin";
     id: number;
+    email: string;
     githubUsername: string;
     updatedAt: string;
     createdAt: string;
     authToken?: string | null;
+    jwt?: string | null;
     archivedAt?: string | null;
   };
 };
@@ -21,9 +24,26 @@ type UserData = {
 export const createNewUser = async ({
   username,
   permissions,
+  email,
 }: CreateUserProp): Promise<UserData> => {
   return axios.post(endpoints.USERS(), {
     username,
     permissions,
+    email,
+  });
+};
+
+// TODO: account for other properties e.g. permissions, jwt, etc.
+export const updateUserProfile = async ({
+  id,
+  email,
+  username,
+}: CreateUserProp & { id: number }): Promise<UserData> => {
+  if (!id) {
+    throw new Error("User id is required");
+  }
+  return axios.put(endpoints.USER_BY_ID(id), {
+    email,
+    username,
   });
 };

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -21,6 +21,7 @@ declare module "next-auth" {
   interface GhExtendedProfile extends Profile {
     login: string;
     avatar_url: string;
+    email: string;
     [key]?: string;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2994,11 +2994,6 @@ match-sorter@^6.3.1:
     "@babel/runtime" "^7.12.5"
     remove-accents "0.4.2"
 
-md-editor-rt@^2.10.1:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/md-editor-rt/-/md-editor-rt-2.10.1.tgz#529d51cf808d720857decb41c44e86699a2e215a"
-  integrity sha512-0rbytgoR2XG5GobBkoS/x9SckfwUOlS9aT34ltDxUM45h580Ud9lRbqzJiIkKdHnQqNUT901Z/4zJ/0xPuc8aw==
-
 mdurl@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"


### PR DESCRIPTION
This pr basically adds the user email (from github) as part of the data send to the backend when an account is created. If it's an existing user without an email, we update the email field in the backend.