### PR TITLE
feat: save edit done on metadata on change

### DIFF
--- a/src/components/sideBarContentEdit/SidebarContentEdit.tsx
+++ b/src/components/sideBarContentEdit/SidebarContentEdit.tsx
@@ -7,7 +7,7 @@ import { ReactNode } from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { MdOutlineAccessTimeFilled } from "react-icons/md";
-import { Review, Transcript } from "../../../types";
+import { Review, Transcript, TranscriptContent } from "../../../types";
 import {
   sideBarContentUpdateParams,
   SideBarData,
@@ -23,6 +23,8 @@ const SidebarContentEdit = ({
   children,
   sideBarData,
   updater,
+  getUpdatedTranscript,
+  saveTranscript,
 }: {
   data: Transcript;
   claimedAt: Review["createdAt"];
@@ -33,9 +35,15 @@ const SidebarContentEdit = ({
     type,
     name,
   }: sideBarContentUpdateParams<T, K>) => void;
+  getUpdatedTranscript: () => TranscriptContent;
+  saveTranscript: (updatedContent: TranscriptContent) => Promise<void>;
 }) => {
   const { data: selectableListData, isLoading, error } = useGetMetaData();
   const updateTitle = (newTitle: string) => {
+    const updatedTranscript = getUpdatedTranscript();
+    updatedTranscript.title = newTitle;
+    saveTranscript(updatedTranscript);
+
     updater({
       data: newTitle,
       type: "text",
@@ -43,13 +51,28 @@ const SidebarContentEdit = ({
     });
   };
   const updateSpeaker = (speakers: string[]) => {
+    const updatedTranscript = getUpdatedTranscript();
+    updatedTranscript.speakers = speakers;
+    saveTranscript(updatedTranscript);
+
     updater({
       data: speakers,
       type: "list",
       name: "speakers",
     });
   };
+  const updateDate = (date: Date) => {
+    const updatedTranscript = getUpdatedTranscript();
+    updatedTranscript.date = date;
+    saveTranscript(updatedTranscript);
+
+    updater({ data: date, type: "date", name: "date" });
+  };
   const updateCategories = (categories: string[]) => {
+    const updatedTranscript = getUpdatedTranscript();
+    updatedTranscript.categories = categories;
+    saveTranscript(updatedTranscript);
+
     updater({
       data: categories,
       type: "list",
@@ -57,6 +80,10 @@ const SidebarContentEdit = ({
     });
   };
   const updateTags = (tags: string[]) => {
+    const updatedTranscript = getUpdatedTranscript();
+    updatedTranscript.tags = tags;
+    saveTranscript(updatedTranscript);
+
     updater({
       data: tags,
       type: "list",
@@ -132,9 +159,7 @@ const SidebarContentEdit = ({
           {/* <CustomDatePicker date={editedDate} onChange={setEditedDate} /> */}
           <DatePicker
             selected={sideBarData.date.date}
-            onChange={(date) =>
-              updater({ data: date, type: "date", name: "date" })
-            }
+            onChange={updateDate}
             dateFormat="yyyy-MM-dd"
             className={styles.customDatePicker}
           />

--- a/src/components/transcript/index.tsx
+++ b/src/components/transcript/index.tsx
@@ -6,6 +6,7 @@ import SubmitTranscriptMenu from "@/components/menus/SubmitTranscriptMenu";
 import type { SubmitState } from "@/components/modals/SubmitTranscriptModal";
 import SubmitTranscriptModal from "@/components/modals/SubmitTranscriptModal";
 import SidebarContentEdit from "@/components/sideBarContentEdit/SidebarContentEdit";
+import config from "@/config/config.json";
 import { useSubmitReview } from "@/services/api/reviews/useSubmitReview";
 import { useUpdateTranscript } from "@/services/api/transcripts";
 import {
@@ -20,8 +21,7 @@ import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useRef, useState } from "react";
 import MdEditor from "react-markdown-editor-lite";
-import type { UserReview } from "../../../types";
-import config from "@/config/config.json";
+import type { TranscriptContent, UserReview } from "../../../types";
 
 const defaultSubmitState = {
   stepIdx: 0,
@@ -136,7 +136,7 @@ const Transcript = ({ reviewData }: { reviewData: UserReview }) => {
     setEditedData(transcriptData.originalContent.body ?? "");
   };
 
-  const saveTranscript = async () => {
+  const getUpdatedContent = () => {
     const {
       list: { speakers, categories, tags },
       text: { title },
@@ -152,6 +152,11 @@ const Transcript = ({ reviewData }: { reviewData: UserReview }) => {
       date,
       body: editedData,
     };
+
+    return updatedContent;
+  };
+
+  const saveTranscript = async (updatedContent: TranscriptContent) => {
     // create an awaitable promise for mutation
     try {
       await mutateAsync(
@@ -171,7 +176,7 @@ const Transcript = ({ reviewData }: { reviewData: UserReview }) => {
 
   const handleSave = async () => {
     try {
-      await saveTranscript();
+      await saveTranscript(getUpdatedContent());
       toast({
         status: "success",
         title: "Saved successfully",
@@ -194,7 +199,7 @@ const Transcript = ({ reviewData }: { reviewData: UserReview }) => {
     setSubmitState((prev) => ({ ...prev, isLoading: true, isModalOpen: true }));
     try {
       // save transcript
-      await saveTranscript();
+      await saveTranscript(getUpdatedContent());
       setSubmitState((prev) => ({ ...prev, stepIdx: 1 }));
 
       // fork and create pr
@@ -253,6 +258,8 @@ const Transcript = ({ reviewData }: { reviewData: UserReview }) => {
             claimedAt={reviewData.createdAt}
             sideBarData={sideBarData}
             updater={sideBarContentUpdater}
+            getUpdatedTranscript={getUpdatedContent}
+            saveTranscript={saveTranscript}
           >
             <Flex gap={2}>
               <Button


### PR DESCRIPTION
Fixes: https://github.com/bitcointranscripts/transcription-review-front-end/issues/61

Metdata on the edit page are saved on change