### PR TITLE
fix: account redirects and jwt invalidation

### DIFF
--- a/src/components/navbar/Menu.tsx
+++ b/src/components/navbar/Menu.tsx
@@ -13,21 +13,26 @@ import {
   Heading,
   Icon,
   Text,
+  useToast,
 } from "@chakra-ui/react";
 import { signIn, signOut, useSession } from "next-auth/react";
 import Image from "next/image";
 import { useRouter } from "next/router";
 import { useState } from "react";
+import { CgTranscript } from "react-icons/cg";
 import { FaGithub } from "react-icons/fa";
-import { FiHome, FiUser } from "react-icons/fi";
+import { RiWalletLine } from "react-icons/ri";
+import { FiUser } from "react-icons/fi";
 import { HiOutlineBookOpen } from "react-icons/hi";
 import MenuNav from "./MenuNav";
+import { useLogout } from "@/services/api/useLogout";
 
 const Menu = () => {
   const { data: userSession } = useSession();
+  const { mutateAsync: requestLogout } = useLogout();
   const router = useRouter();
   const currentRoute = router.asPath?.split("/")[1] ?? "";
-
+  const toast = useToast();
   const [menuOpen, setMenuOpen] = useState(false);
   const closeMenu = () => {
     setMenuOpen(false);
@@ -37,6 +42,19 @@ const Menu = () => {
     setMenuOpen(true);
   };
 
+  const handleSecureLogout = async () => {
+    try {
+      await requestLogout();
+      await signOut({ redirect: false });
+      await router.push("/");
+    } catch (err) {
+      toast({
+        title: "Error",
+        description: `${err}`,
+        status: "error",
+      });
+    }
+  };
   return (
     <>
       {!userSession ? (
@@ -113,13 +131,6 @@ const Menu = () => {
                       Pages
                     </Heading>
                     <Flex mt={4} direction="column" gap={2}>
-                      <MenuNav
-                        currentRoute={currentRoute}
-                        routeName="home"
-                        routeLink={ROUTES_CONFIG.HOME}
-                        handleClose={closeMenu}
-                        icon={FiHome}
-                      />
                       {userSession?.user?.githubUsername && (
                         <MenuNav
                           routeName="account"
@@ -129,6 +140,13 @@ const Menu = () => {
                           icon={FiUser}
                         />
                       )}
+                      <MenuNav
+                        currentRoute={currentRoute}
+                        routeName={ROUTES_CONFIG.TRANSCRIPTS}
+                        routeLink={ROUTES_CONFIG.TRANSCRIPTS}
+                        handleClose={closeMenu}
+                        icon={CgTranscript}
+                      />
                       <MenuNav
                         currentRoute={currentRoute}
                         routeName={ROUTES_CONFIG.TUTORIAL}
@@ -141,7 +159,7 @@ const Menu = () => {
                         routeName={"wallet"}
                         routeLink={"wallet"}
                         handleClose={closeMenu}
-                        icon={HiOutlineBookOpen}
+                        icon={RiWalletLine}
                       />
                     </Flex>
                   </Box>
@@ -151,7 +169,7 @@ const Menu = () => {
                       colorScheme="red"
                       variant="outline"
                       size="sm"
-                      onClick={() => signOut()}
+                      onClick={handleSecureLogout}
                     >
                       Sign out
                     </Button>

--- a/src/components/tables/CurrentJobsTable.tsx
+++ b/src/components/tables/CurrentJobsTable.tsx
@@ -143,7 +143,7 @@ const EmptyView = () => {
   return (
     <Flex w="full" justifyContent="center" alignItems="center" gap={2}>
       <Text>No Current Jobs 😭</Text>
-      <Link href="/">
+      <Link href="/transcripts">
         <Button size="xs" colorScheme="orange">
           Choose transcript to edit
         </Button>

--- a/src/config/ui-config.ts
+++ b/src/config/ui-config.ts
@@ -3,6 +3,7 @@
 export const ROUTES_CONFIG = {
   HOME: "",
   TUTORIAL: "tutorial",
+  TRANSCRIPTS: "transcripts",
 };
 
 export const UI_CONFIG = {

--- a/src/pages/[username]/index.tsx
+++ b/src/pages/[username]/index.tsx
@@ -1,5 +1,4 @@
 import CurrentJobsTable from "@/components/tables/CurrentJobsTable";
-import EditableTranscriptsTable from "@/components/tables/EditableTranscriptsTable";
 import PastJobsTable from "@/components/tables/PastJobsTable";
 import { Heading } from "@chakra-ui/react";
 
@@ -9,7 +8,6 @@ export default function Profile() {
       <Heading size="md" mb={6}>
         My Account
       </Heading>
-      <EditableTranscriptsTable />
       <CurrentJobsTable />
       <PastJobsTable />
     </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable react/no-unescaped-entities */
-import HomePage from "@/components/home/Queuer";
 import HomePageTutorial from "@/components/home/Tutorial";
 import { GetServerSideProps, GetServerSidePropsContext, NextPage } from "next";
 import type { Session } from "next-auth";
 import { getServerSession } from "next-auth/next";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
 import { authOptions } from "./api/auth/[...nextauth]";
 
 type HomePageProps = {
@@ -11,8 +12,14 @@ type HomePageProps = {
 };
 
 const Home: NextPage<HomePageProps> = ({ serverSession }) => {
+  const router = useRouter();
+  useEffect(() => {
+    if (serverSession) {
+      router.push(`/${serverSession.user?.githubUsername || "no-user"}`);
+    }
+  }, [serverSession, router]);
   if (serverSession) {
-    return <HomePage />;
+    return <></>;
   }
 
   return <HomePageTutorial />;

--- a/src/pages/transcripts/index.tsx
+++ b/src/pages/transcripts/index.tsx
@@ -1,0 +1,8 @@
+import HomePage from "@/components/home/Queuer";
+import React from "react";
+
+const TranscriptsHome = () => {
+  return <HomePage />;
+};
+
+export default TranscriptsHome;

--- a/src/services/api/useLogout.ts
+++ b/src/services/api/useLogout.ts
@@ -1,0 +1,18 @@
+import { useMutation } from "@tanstack/react-query";
+import axios from "./axios";
+import endpoints from "./endpoints";
+
+const logout = async () => {
+  return axios
+    .post(endpoints.USER_SIGN_OUT())
+    .then((res) => {
+      return res.data;
+    })
+    .catch((err) => {
+      const errMessage =
+        err?.response?.data?.message || "Please try again later";
+      throw new Error(errMessage);
+    });
+};
+
+export const useLogout = () => useMutation({ mutationFn: logout });


### PR DESCRIPTION
1. This PR redirects from "/" to /[username] when there is a user in sessions, if there is none it shows the / with the tutorial page

2. Also, the transcripts to edit are currently in /transcripts, and the redirect is triggered only when choose transcript is clicked

3. #136  Reclaimable table has also been removed from this PR

4. Wallet icon has been changed

5. Added Transcripts to the menu.

6. jwt invalidation with the logout endpoint