### PR TITLE
Display transcript's directory during selection

### DIFF
--- a/src/components/tables/QueueTable.tsx
+++ b/src/components/tables/QueueTable.tsx
@@ -201,6 +201,7 @@ const QueueTable = () => {
                 title={data.content.title}
                 allTags={allTags}
                 categories={data.content.categories}
+                loc={data.content.loc}
                 id={data.id}
                 length={allTags.length}
                 shouldSlice={false}

--- a/src/components/tables/TitleWithTags.tsx
+++ b/src/components/tables/TitleWithTags.tsx
@@ -9,6 +9,7 @@ type TitleWithTagsProps = {
   title: string;
   id: number;
   categories: string | string[];
+  loc?: string;
   allTags: string[];
   length: number;
   shouldSlice?: boolean;
@@ -17,6 +18,7 @@ const TitleWithTags = ({
   title,
   allTags,
   categories,
+  loc,
   id,
   length,
   shouldSlice = true,
@@ -33,7 +35,10 @@ const TitleWithTags = ({
   return (
     <Td width="40%">
       <Flex gap={2} flexDir="column">
-        <Text>{title}</Text>
+        <Box>
+          <Text>{title}</Text>
+          <Text fontSize={["0.7rem"]} color="gray.500">{loc}</Text>
+        </Box>
         <Flex wrap="wrap" gap={2} alignItems="center">
           {foundCategories && (
             <Box

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,7 +85,7 @@ export class Metadata {
     // eslint-disable-next-line prettier/prettier
     this.metaData =
       `---\n` +
-      `title: ${fileTitle}\n` +
+      `title: "${fileTitle}"\n` +
       `transcript_by: ${transcript_by} via ${config.app_tag}\n`;
 
     this.metaData += `media: ${url}\n`;


### PR DESCRIPTION
directory (`loc`) provides additional information about the transcript that we can use to provide more context to the reviewer
![Screenshot from 2023-11-16 18-20-37](https://github.com/bitcointranscripts/transcription-review-front-end/assets/18506343/2a212197-d643-40cb-9654-826db4c524b8)
