### PR TITLE
Add feedback prompt after submitting transcript

### DIFF
--- a/src/components/modals/SubmitTranscriptModal.tsx
+++ b/src/components/modals/SubmitTranscriptModal.tsx
@@ -1,3 +1,4 @@
+import { discordInvites } from "@/utils";
 import {
   Box,
   Divider,
@@ -68,10 +69,10 @@ const SubmitTranscriptModal = ({ submitState, onClose }: Props) => {
                       stepLoading
                         ? "orange.400"
                         : stepCompleted
-                        ? "green.400"
-                        : stepNotRun
-                        ? "gray.300"
-                        : "red.400"
+                          ? "green.400"
+                          : stepNotRun
+                            ? "gray.300"
+                            : "red.400"
                     }
                     fontWeight={stepNotRun ? 300 : 600}
                   >
@@ -124,6 +125,19 @@ const SubmitTranscriptModal = ({ submitState, onClose }: Props) => {
                       color="blue.400"
                     >
                       here
+                    </Link>
+                    .
+                  </Text>
+                  <Divider marginY={2} />
+                  <Text fontSize="sm" alignSelf='end'>
+                    Help us improve!{" "}
+                    <Link
+                      href={discordInvites.feedback}
+                      target="_blank"
+                      color="blue.400"
+                      data-umami-event="discord-feedback"
+                    >
+                      Tell us about your experience
                     </Link>
                     .
                   </Text>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -367,4 +367,5 @@ export const guidelinesReviewArray = [
 
 export const discordInvites = {
   review_guidelines: "https://discord.gg/jqj4maCs8p",
+  feedback: "https://discord.gg/W4cmWRhMnr"
 };


### PR DESCRIPTION
The link redirects to the generic feedback form that we use across all the projects. I'm currently discussing with @aassoiants if it makes sense to change that.

### Before
![before](https://github.com/bitcointranscripts/transcription-review-front-end/assets/18506343/9d5e5b69-22ce-4e97-93a8-faeddf829806)

### After
![after](https://github.com/bitcointranscripts/transcription-review-front-end/assets/18506343/dd97dcd2-65fc-40b1-8425-ff4ef5d08060)
