### PR TITLE
fix: prevent claim when active review

### DIFF
--- a/src/services/api/reviews/useUserReviews.ts
+++ b/src/services/api/reviews/useUserReviews.ts
@@ -1,3 +1,4 @@
+import config from "@/config/config.json";
 import {
   RefetchOptions,
   RefetchQueryFilters,
@@ -7,6 +8,7 @@ import {
 import type { UserReview } from "../../../../types";
 import axios from "../axios";
 import endpoints, { ReviewQueryOptions } from "../endpoints";
+import { isReviewActive } from "@/utils";
 
 const userReviews = async ({
   userId,
@@ -72,4 +74,12 @@ export const useUserMultipleReviews = ({
     refetch,
     isError: queryInfo.some((query) => query.isError),
   };
+};
+
+export const useHasExceededMaxActiveReviews = (userId: number | undefined) => {
+  const { data: allReviews = { data: [] } } = useUserReviews({
+    userId,
+  });
+  const activeReviews = allReviews?.data?.filter(isReviewActive);
+  return activeReviews.length >= config.max_active_reviews;
 };


### PR DESCRIPTION
Prevent the users from claiming a transcript when they have more than the max active reviews.

Fixes https://github.com/bitcointranscripts/transcription-review-front-end/issues/261