### PR TITLE
feat: support arbitrary fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "bolt11": "^1.4.1",
     "date-fns": "^2.30.0",
     "framer-motion": "^10.15.1",
+    "js-yaml": "^4.1.0",
     "jsonwebtoken": "^9.0.1",
     "jwt-decode": "^3.1.2",
     "markdown-it": "^13.0.1",
@@ -41,6 +42,7 @@
     "use-debounce": "^10.0.0"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/marked": "^5.0.1",
     "@types/node": "^20.4.9",
     "@types/react": "^18.2.19",

--- a/src/components/modals/ReviewGuidelinesModal.tsx
+++ b/src/components/modals/ReviewGuidelinesModal.tsx
@@ -70,7 +70,6 @@ const GuidelinesContent = forwardRef<HTMLButtonElement, GuidelinesContentProps>(
     return (
       <>
         <ModalHeader fontSize="2xl" fontWeight="bold" paddingBottom={0}>
-        <ModalHeader fontSize="2xl" fontWeight="bold" paddingBottom={0}>
           Review Guidelines
         </ModalHeader>
         <ModalBody>

--- a/src/components/modals/ReviewGuidelinesModal.tsx
+++ b/src/components/modals/ReviewGuidelinesModal.tsx
@@ -70,6 +70,7 @@ const GuidelinesContent = forwardRef<HTMLButtonElement, GuidelinesContentProps>(
     return (
       <>
         <ModalHeader fontSize="2xl" fontWeight="bold" paddingBottom={0}>
+        <ModalHeader fontSize="2xl" fontWeight="bold" paddingBottom={0}>
           Review Guidelines
         </ModalHeader>
         <ModalBody>
@@ -78,6 +79,23 @@ const GuidelinesContent = forwardRef<HTMLButtonElement, GuidelinesContentProps>(
               To ensure a shared quality of transcripts, please follow the
               guidelines below
             </Text>
+            {guidelinesReviewArray.map((guideline) => (
+              <Flex
+                key={guideline.heading}
+                flexDir={"column"}
+                gap={2}
+              >
+                <Heading size='md'>{guideline.heading}</Heading>
+                <UnorderedList pl={3} color="gray.700" fontSize="14px">
+                  {guideline.paragraphs.map((paragraph) => (
+                    <ListItem key={paragraph}>
+                      <Text dangerouslySetInnerHTML={{ __html: mdParser.render(paragraph) }}></Text>
+                    </ListItem>
+                  ))}
+                </UnorderedList>
+
+              </Flex>
+            ))}
             <>
               <Divider marginY={2} />
               <Text fontSize="sm" alignSelf="end">

--- a/src/components/modals/ReviewGuidelinesModal.tsx
+++ b/src/components/modals/ReviewGuidelinesModal.tsx
@@ -79,23 +79,6 @@ const GuidelinesContent = forwardRef<HTMLButtonElement, GuidelinesContentProps>(
               To ensure a shared quality of transcripts, please follow the
               guidelines below
             </Text>
-            {guidelinesReviewArray.map((guideline) => (
-              <Flex
-                key={guideline.heading}
-                flexDir={"column"}
-                gap={2}
-              >
-                <Heading size='md'>{guideline.heading}</Heading>
-                <UnorderedList pl={3} color="gray.700" fontSize="14px">
-                  {guideline.paragraphs.map((paragraph) => (
-                    <ListItem key={paragraph}>
-                      <Text dangerouslySetInnerHTML={{ __html: mdParser.render(paragraph) }}></Text>
-                    </ListItem>
-                  ))}
-                </UnorderedList>
-
-              </Flex>
-            ))}
             <>
               <Divider marginY={2} />
               <Text fontSize="sm" alignSelf="end">

--- a/src/components/sideBarContentEdit/CategoryEdit.tsx
+++ b/src/components/sideBarContentEdit/CategoryEdit.tsx
@@ -33,16 +33,21 @@ export function ListEdit(
         type: "singleSelect";
       })
   ) & {
-    heading: string;
+    heading: string | JSX.Element;
   }
 ) {
   return (
     <Box>
-      <Text fontWeight={600} mb={2}>
-        {props.heading}
-      </Text>
+      {typeof props.heading === "string" ? (
+        <Text fontWeight={600} mb={2}>
+          {props.heading}
+        </Text>
+      ) : (
+        props.heading
+      )}
+
       {props.type === "onlySelect" ? (
-        <OnlySelectField {...props} />
+        <OnlySelectField userCanAddToList {...props} />
       ) : (
         <SingleSelectField {...props} />
       )}

--- a/src/components/sideBarContentEdit/CategoryEdit.tsx
+++ b/src/components/sideBarContentEdit/CategoryEdit.tsx
@@ -27,10 +27,10 @@ export function TextEdit({
 export function ListEdit(
   props: (
     | (React.ComponentProps<typeof OnlySelectField> & {
-        type?: "onlySelect";
+        type: "onlySelect";
       })
     | (React.ComponentProps<typeof SingleSelectField> & {
-        type?: "singleSelect";
+        type: "singleSelect";
       })
   ) & {
     heading: string;

--- a/src/components/sideBarContentEdit/CategoryEdit.tsx
+++ b/src/components/sideBarContentEdit/CategoryEdit.tsx
@@ -1,0 +1,78 @@
+import { Box, Text } from "@chakra-ui/react";
+import DatePicker from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
+import { OnlySelectField, SingleSelectField } from "./SelectField";
+import TextField from "./TextField";
+import styles from "./sidebarContentEdit.module.css";
+
+export function TextEdit({
+  editedData,
+  heading,
+  updateData,
+}: {
+  editedData: string;
+  heading: string;
+  updateData: (value: string) => void;
+}) {
+  return (
+    <Box>
+      <Text fontWeight={600} mb={2}>
+        {heading}
+      </Text>
+      <TextField editedData={editedData} updateData={updateData} />
+    </Box>
+  );
+}
+
+export function ListEdit(
+  props: (
+    | (React.ComponentProps<typeof OnlySelectField> & {
+        type?: "onlySelect";
+      })
+    | (React.ComponentProps<typeof SingleSelectField> & {
+        type?: "singleSelect";
+      })
+  ) & {
+    heading: string;
+  }
+) {
+  return (
+    <Box>
+      <Text fontWeight={600} mb={2}>
+        {props.heading}
+      </Text>
+      {props.type === "onlySelect" ? (
+        <OnlySelectField {...props} />
+      ) : (
+        <SingleSelectField {...props} />
+      )}
+    </Box>
+  );
+}
+
+export function DateEdit({
+  editedData,
+  heading,
+  updateData,
+}: {
+  editedData: Date | null;
+  heading: string;
+  updateData: (value: Date) => void;
+}) {
+  return (
+    <Box>
+      <Text display="inline-block" fontWeight={600} mb={2}>
+        {heading}
+      </Text>
+      <Text ml={3} display="inline-block" color="gray.400">
+        YYYY-MM-DD format
+      </Text>
+      <DatePicker
+        selected={editedData}
+        onChange={updateData}
+        dateFormat="yyyy-MM-dd"
+        className={styles.customDatePicker}
+      />
+    </Box>
+  );
+}

--- a/src/components/sideBarContentEdit/SidebarContentEdit.tsx
+++ b/src/components/sideBarContentEdit/SidebarContentEdit.tsx
@@ -1,6 +1,12 @@
 import config from "@/config/config.json";
 import { useGetMetaData } from "@/services/api/transcripts/useGetMetaData";
-import { getTimeLeftText, knownMetaData, omit, toTitleCase } from "@/utils";
+import {
+  getTimeLeftText,
+  isStringArray,
+  knownMetaData,
+  omit,
+  toTitleCase,
+} from "@/utils";
 import { Box, Button, Flex, Text } from "@chakra-ui/react";
 import Link from "next/link";
 import { ReactNode, useEffect, useState } from "react";
@@ -217,7 +223,7 @@ const SidebarContentEdit = ({
         {Object.keys(arbitraryFields).map((field) => {
           const fieldValue = arbitraryFields[field];
 
-          if (Array.isArray(fieldValue)) {
+          if (Array.isArray(fieldValue) && isStringArray(fieldValue)) {
             return (
               <ListEdit
                 key={field}
@@ -225,7 +231,7 @@ const SidebarContentEdit = ({
                 type="singleSelect"
                 heading={toTitleCase(field)}
                 name={field}
-                editedData={sideBarData.list[field]}
+                editedData={fieldValue}
                 updateData={updateListField(field)}
                 // TODO: Determine how to autocomplete for arbitrary data that is an array
                 autoCompleteList={selectableListData?.categories ?? []}
@@ -237,7 +243,7 @@ const SidebarContentEdit = ({
             return (
               <TextEdit
                 key={field}
-                editedData={sideBarData.text[field]}
+                editedData={fieldValue}
                 updateData={updateTextField(field)}
                 heading={toTitleCase(field)}
               />
@@ -249,7 +255,7 @@ const SidebarContentEdit = ({
               <DateEdit
                 key={field}
                 heading={toTitleCase(field)}
-                editedData={sideBarData.date[field]}
+                editedData={fieldValue}
                 updateData={updateDateField(field)}
               />
             );

--- a/src/components/sideBarContentEdit/SidebarContentEdit.tsx
+++ b/src/components/sideBarContentEdit/SidebarContentEdit.tsx
@@ -5,7 +5,9 @@ import {
   isStringArray,
   knownMetaData,
   omit,
+  pick,
   toTitleCase,
+  whitelistedArbitraryMetaData,
 } from "@/utils";
 import { Box, Button, Flex, Text } from "@chakra-ui/react";
 import Link from "next/link";
@@ -123,13 +125,16 @@ const SidebarContentEdit = ({
     }
   }, []);
 
-  const arbitraryFields = omit(
-    {
-      ...sideBarData.text,
-      ...sideBarData.list,
-      ...sideBarData.date,
-    },
-    knownMetaData
+  const arbitraryFields = pick(
+    omit(
+      {
+        ...sideBarData.text,
+        ...sideBarData.list,
+        ...sideBarData.date,
+      },
+      knownMetaData
+    ),
+    whitelistedArbitraryMetaData
   ) as Record<string, ArbitraryFieldValues>;
 
   return (

--- a/src/components/sideBarContentEdit/SidebarContentEdit.tsx
+++ b/src/components/sideBarContentEdit/SidebarContentEdit.tsx
@@ -181,6 +181,7 @@ const SidebarContentEdit = ({
           heading="Title"
         />
         <ListEdit
+          type="onlySelect"
           heading="Speakers"
           name="speakers"
           editedData={sideBarData.list.speakers}

--- a/src/components/sideBarContentEdit/SidebarContentEdit.tsx
+++ b/src/components/sideBarContentEdit/SidebarContentEdit.tsx
@@ -28,7 +28,6 @@ import {
   sideBarContentUpdateParams,
 } from "../transcript";
 import { DateEdit, ListEdit, TextEdit } from "./CategoryEdit";
-import { OnlySelectField } from "./SelectField";
 
 function extractDirFormat(input: Record<string, any> = {}): IDir[] {
   if (Object.keys(input).length === 0) return [];
@@ -202,30 +201,31 @@ const SidebarContentEdit = ({
           updateData={updateListField("categories")}
           autoCompleteList={selectableListData?.categories ?? []}
         />
-        <Box>
-          <Flex gap={2}>
-            <Text fontWeight={600} mb={2}>
-              Tags
-            </Text>
-            <span>
-              (
-              <Link href="https://btctranscripts.com/tags/" target="_blank">
-                <Text display="inline" color="blue.600" fontSize="12px">
-                  What&apos;s this?
-                </Text>
-              </Link>
-              )
-            </span>
-          </Flex>
-          <OnlySelectField
-            name="tags"
-            editedData={sideBarData.list.tags}
-            updateData={(tags) =>
-              updateListField("tags")(tags.map((tag) => tag.toLowerCase()))
-            }
-            autoCompleteList={selectableListData?.tags ?? []}
-          />
-        </Box>
+        <ListEdit
+          type="onlySelect"
+          heading={
+            <Flex gap={2}>
+              <Text fontWeight={600} mb={2}>
+                Tags
+              </Text>
+              <span>
+                (
+                <Link href="https://btctranscripts.com/tags/" target="_blank">
+                  <Text display="inline" color="blue.600" fontSize="12px">
+                    What&apos;s this?
+                  </Text>
+                </Link>
+                )
+              </span>
+            </Flex>
+          }
+          name="tags"
+          editedData={sideBarData.list.tags}
+          updateData={(tags) =>
+            updateListField("tags")(tags.map((tag) => tag.toLowerCase()))
+          }
+          autoCompleteList={selectableListData?.tags ?? []}
+        />
         {Object.keys(arbitraryFields).map((field) => {
           const fieldValue = arbitraryFields[field];
 

--- a/src/components/transcript/index.tsx
+++ b/src/components/transcript/index.tsx
@@ -217,16 +217,8 @@ const Transcript = ({ reviewData }: { reviewData: UserReviewData }) => {
       ghSourcePath,
       ghBranchUrl,
       reviewId: reviewData.id,
+      ...omit(restContent, ["media", "transcript_by"]),
     };
-
-    for (const field of Object.keys(
-      omit(restContent, ["media", "transcript_by"])
-    )) {
-      const fieldValue = restContent[field];
-      if (fieldValue) {
-        newImplData[field] = formatDataForMetadata(fieldValue);
-      }
-    }
 
     const isPreviousHash = compareTranscriptBetweenSave(newImplData);
     if (isPreviousHash) {
@@ -253,12 +245,7 @@ const Transcript = ({ reviewData }: { reviewData: UserReviewData }) => {
   };
 
   const handleSubmit = async () => {
-    const {
-      list: { speakers, categories, tags },
-      text: { title },
-      loc: { loc },
-      date: { date },
-    } = sideBarData;
+    const { loc, title, date, ...restContent } = getUpdatedContent();
     setSubmitState((prev) => ({ ...prev, isLoading: true, isModalOpen: true }));
     try {
       // save transcript
@@ -277,9 +264,6 @@ const Transcript = ({ reviewData }: { reviewData: UserReviewData }) => {
         url: transcriptData?.content.media,
         prUrl: reviewData?.pr_url,
         date: date && dateFormatGeneral(date, true),
-        tags: formatDataForMetadata(tags),
-        speakers: formatDataForMetadata(speakers),
-        categories: formatDataForMetadata(categories),
         transcribedText: editedData,
         transcript_by: formatDataForMetadata(
           userSession?.user?.githubUsername ?? ""
@@ -287,6 +271,7 @@ const Transcript = ({ reviewData }: { reviewData: UserReviewData }) => {
         prRepo,
         ghSourcePath,
         ghBranchUrl,
+        ...omit(restContent, ["media", "transcript_by"]),
       });
       setSubmitState((prev) => ({ ...prev, stepIdx: 2, prResult }));
       localStorage.removeItem("oldDirectoryList");

--- a/src/components/transcript/index.tsx
+++ b/src/components/transcript/index.tsx
@@ -185,21 +185,14 @@ const Transcript = ({ reviewData }: { reviewData: UserReviewData }) => {
   };
 
   const getUpdatedContent = () => {
-    const {
-      list: { speakers, categories, tags },
-      text: { title },
-      loc: { loc },
-      date: { date },
-    } = sideBarData;
+    const { list, text, loc, date } = sideBarData;
     const content = transcriptData.content;
     const updatedContent = {
       ...content,
-      title,
-      speakers,
-      categories,
-      tags,
-      date,
-      loc,
+      ...list,
+      ...text,
+      ...loc,
+      ...date,
       body: editedData,
     };
 

--- a/src/pages/api/github/pr.ts
+++ b/src/pages/api/github/pr.ts
@@ -421,6 +421,7 @@ export default async function handler(
     prUrl,
     ghSourcePath,
     ghBranchUrl,
+    ...otherMetaData
   } = req.body;
   const pull_number = extractPullNumber(prUrl || "");
   try {
@@ -433,6 +434,7 @@ export default async function handler(
       tags,
       speakers,
       categories,
+      ...otherMetaData,
     });
 
     if (ghBranchUrl) {

--- a/src/pages/api/github/save.ts
+++ b/src/pages/api/github/save.ts
@@ -176,6 +176,7 @@ export default async function handler(
     ghBranchUrl,
     directoryPath,
     reviewId,
+    ...otherMetaData
   } = req.body;
 
   const newMetadata = new Metadata({
@@ -186,6 +187,7 @@ export default async function handler(
     tags,
     speakers,
     categories,
+    ...otherMetaData,
   });
 
   const transcriptData = {

--- a/src/pages/wallet/index.tsx
+++ b/src/pages/wallet/index.tsx
@@ -24,7 +24,7 @@ import TransactionsTable from "@/components/tables/TransactionsTable";
 import { useGetWallet } from "@/services/api/wallet";
 
 import { Transaction } from "../../../types";
-import MaintenanceBanner from '@/components/banner/MaintenanceBanner';
+import MaintenanceBanner from "@/components/banner/MaintenanceBanner";
 
 type OnSelect<T> = (item: T) => void;
 

--- a/src/services/api/transcripts/useUpdateTranscript.ts
+++ b/src/services/api/transcripts/useUpdateTranscript.ts
@@ -27,6 +27,7 @@ const updateTranscript = async (body: {
       ghSourcePath,
       ghBranchUrl,
       reviewId,
+      ...otherMetaData
     } = newImplData;
 
     return axios
@@ -43,6 +44,7 @@ const updateTranscript = async (body: {
         ghSourcePath,
         ghBranchUrl,
         reviewId,
+        ...otherMetaData,
       })
       .then((res) => {
         return res;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -162,6 +162,18 @@ export function reconcileArray(possibleArray: unknown): string[] {
   return [];
 }
 
+export function parseJsonArray<T>(possibleArray: unknown): {
+  ok: boolean;
+  data: T | null;
+} {
+  try {
+    const data = JSON.parse(possibleArray as string);
+    return { ok: Array.isArray(data), data };
+  } catch (e) {
+    return { ok: false, data: null };
+  }
+}
+
 export function newIndexFile(directoryName: string) {
   const title = directoryName
     .split("-")

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -384,3 +384,7 @@ export function toTitleCase(str: string) {
     })
     .join(" ");
 }
+
+export function isStringArray(arr: string[] | unknown[]): arr is string[] {
+  return arr.every((item) => typeof item === "string");
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -351,3 +351,36 @@ export const discordInvites = {
   review_guidelines: "https://discord.gg/jqj4maCs8p",
   feedback: "https://discord.gg/W4cmWRhMnr",
 };
+
+export const knownMetaData = [
+  "title",
+  "speakers",
+  "date",
+  "categories",
+  "tags",
+];
+
+export function omit<
+  Key extends string,
+  OmittedKey extends Key,
+  Object extends Record<Key, unknown>,
+>(object: Object, keysToOmit: OmittedKey[]) {
+  const result = {} as Object;
+  const keys = Object.keys(object) as Key[];
+  keys.forEach((key) => {
+    if (!keysToOmit.includes(key as OmittedKey)) {
+      result[key] = object[key];
+    }
+  });
+  return result as Omit<Object, OmittedKey>;
+}
+
+export function toTitleCase(str: string) {
+  return str
+    .toLowerCase()
+    .split(" ")
+    .map((word) => {
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(" ");
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,6 +6,7 @@ import ClockIcon from "../components/svgs/ClockIcon";
 import GithubIcon from "../components/svgs/GithubIcon";
 import LaptopIcon from "../components/svgs/LaptopIcon";
 import config from "../config/config.json";
+import yaml from "js-yaml";
 
 const claim_duration_in_ms = hoursToMilliseconds(
   config.claim_duration_in_hours
@@ -74,21 +75,19 @@ export class Metadata {
     this.fileTitle = fileTitle;
     this.source = url;
 
+    const jsonData = {
+      title: fileTitle,
+      transcript_by: `${transcript_by} via ${config.app_tag}`,
+      media: url,
+      ...restProps,
+    };
+
     this.metaData =
       `---\n` +
-      `title: "${fileTitle}"\n` +
-      `transcript_by: ${transcript_by} via ${config.app_tag}\n`;
-
-    this.metaData += `media: ${url}\n`;
-
-    for (const field of Object.keys(restProps)) {
-      const fieldValue = restProps[field];
-      if (fieldValue) {
-        this.metaData += `${field}: ${fieldValue}\n`;
-      }
-    }
-
-    this.metaData += `---\n`;
+      yaml.dump(jsonData, {
+        forceQuotes: true,
+      }) +
+      "---\n";
   }
 
   public toString(): string {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -70,19 +70,10 @@ export class Metadata {
   public fileTitle: string;
   public source: string;
 
-  constructor({
-    fileTitle,
-    transcript_by,
-    url,
-    date,
-    tags,
-    speakers,
-    categories,
-  }: MetadataProps) {
+  constructor({ fileTitle, transcript_by, url, ...restProps }: MetadataProps) {
     this.fileTitle = fileTitle;
     this.source = url;
 
-    // eslint-disable-next-line prettier/prettier
     this.metaData =
       `---\n` +
       `title: "${fileTitle}"\n` +
@@ -90,18 +81,12 @@ export class Metadata {
 
     this.metaData += `media: ${url}\n`;
 
-    if (tags) {
-      this.metaData += `tags: ${tags}\n`;
+    for (const field of Object.keys(restProps)) {
+      const fieldValue = restProps[field];
+      if (fieldValue) {
+        this.metaData += `${field}: ${fieldValue}\n`;
+      }
     }
-
-    if (speakers) {
-      this.metaData += `speakers: ${speakers}\n`;
-    }
-
-    if (categories) {
-      this.metaData += `categories: ${categories}\n`;
-    }
-    this.metaData += `date: ${date}\n`;
 
     this.metaData += `---\n`;
   }
@@ -366,5 +351,5 @@ export const guidelinesReviewArray = [
 
 export const discordInvites = {
   review_guidelines: "https://discord.gg/jqj4maCs8p",
-  feedback: "https://discord.gg/W4cmWRhMnr"
+  feedback: "https://discord.gg/W4cmWRhMnr",
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 import { format, hoursToMilliseconds, millisecondsToHours } from "date-fns";
 import { NextApiRequest } from "next";
 import slugify from "slugify";
-import { ArbitraryFieldValues, MetadataProps } from "../../types";
+import { ArbitraryFieldValues, Flatten, MetadataProps } from "../../types";
 import ClockIcon from "../components/svgs/ClockIcon";
 import GithubIcon from "../components/svgs/GithubIcon";
 import LaptopIcon from "../components/svgs/LaptopIcon";
@@ -360,19 +360,32 @@ export const knownMetaData = [
   "tags",
 ];
 
+export const whitelistedArbitraryMetaData = [];
+
 export function omit<
-  Key extends string,
-  OmittedKey extends Key,
-  Object extends Record<Key, unknown>,
->(object: Object, keysToOmit: OmittedKey[]) {
+  Object extends Record<string, unknown>,
+  OmittedKeys extends keyof Object,
+>(object: Object, keysToOmit: OmittedKeys[]) {
   const result = {} as Object;
-  const keys = Object.keys(object) as Key[];
-  keys.forEach((key) => {
-    if (!keysToOmit.includes(key as OmittedKey)) {
+  (Object.keys(object) as Array<keyof Object>).forEach((key) => {
+    if (!keysToOmit.includes(key as OmittedKeys)) {
       result[key] = object[key];
     }
   });
-  return result as Omit<Object, OmittedKey>;
+  return result as Flatten<Omit<Object, OmittedKeys>>;
+}
+
+export function pick<
+  Object extends Record<string, unknown>,
+  PickedKeys extends keyof Object,
+>(object: Object, keysToPick: PickedKeys[]) {
+  const result = {} as Flatten<Pick<Object, PickedKeys>>;
+  keysToPick.forEach((key) => {
+    if (key in object) {
+      result[key] = object[key];
+    }
+  });
+  return result;
 }
 
 export function toTitleCase(str: string) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 import { format, hoursToMilliseconds, millisecondsToHours } from "date-fns";
 import { NextApiRequest } from "next";
 import slugify from "slugify";
-import { MetadataProps } from "../../types";
+import { ArbitraryFieldValues, MetadataProps } from "../../types";
 import ClockIcon from "../components/svgs/ClockIcon";
 import GithubIcon from "../components/svgs/GithubIcon";
 import LaptopIcon from "../components/svgs/LaptopIcon";
@@ -123,17 +123,15 @@ export function getRequestUrl(req: NextApiRequest) {
   return requestUrl;
 }
 
-export function formatDataForMetadata(data: string[] | string) {
-  if (Array.isArray(data)) {
-    if (data.length) {
+export function formatDataForMetadata(data: ArbitraryFieldValues) {
+  switch (true) {
+    case typeof data === "boolean":
+    case Array.isArray(data) && !!data.length:
       return JSON.stringify(data);
-    } else {
+    case typeof data === "string" && !!data.trim():
+      return data?.toString();
+    default:
       return undefined;
-    }
-  } else if (data.trim()) {
-    return data;
-  } else {
-    return undefined;
   }
 }
 

--- a/types.ts
+++ b/types.ts
@@ -202,3 +202,9 @@ export type SaveToGHData = Record<string, unknown> & {
   ghBranchUrl: string | null;
   reviewId: number;
 };
+
+export type Identity<T> = T;
+
+export type Flatten<T> = Identity<{
+  [K in keyof T]: T[K];
+}>;

--- a/types.ts
+++ b/types.ts
@@ -55,7 +55,13 @@ export type UserReview = {
   data: UserReviewData[];
 };
 
-export type ArbitraryFieldValues = string | Date | boolean | string[] | null;
+export type ArbitraryFieldValues =
+  | string
+  | Date
+  | boolean
+  | string[]
+  | null
+  | unknown[];
 
 export type TranscriptContent = Record<string, ArbitraryFieldValues> & {
   body: string;

--- a/types.ts
+++ b/types.ts
@@ -55,7 +55,9 @@ export type UserReview = {
   data: UserReviewData[];
 };
 
-export type TranscriptContent = {
+export type ArbitraryFieldValues = string | Date | boolean | string[] | null;
+
+export type TranscriptContent = Record<string, ArbitraryFieldValues> & {
   body: string;
   categories: string[];
   date: Nullable<Date>;
@@ -69,7 +71,7 @@ export type TranscriptContent = {
 
 type Nullable<T> = T | null;
 
-export type MetadataProps = {
+export type MetadataProps = Record<string, ArbitraryFieldValues> & {
   fileTitle: string;
   transcript_by: string;
   url: string;
@@ -173,7 +175,7 @@ export type TransactionQueryType =
 export type TransactionQueryStatus =
   (typeof TransactionStatus)[keyof typeof TransactionStatus];
 
-export type SaveToGHData = {
+export type SaveToGHData = Record<string, unknown> & {
   directoryPath: string;
   fileName?: string;
   url: string | null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1250,6 +1250,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/js-yaml@^4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
+  integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"


### PR DESCRIPTION
Fixes https://github.com/bitcointranscripts/transcription-review-front-end/issues/266

This should work for any arbitrary meta data fields we add in the future. Provided they are of the format we currently support: plain string, array of strings and Date. But I do envision us adding boolean meta data some time in the future.

