### PR TITLE
fix: issue with undefined metadata values

### DIFF
--- a/src/components/sideBarContentEdit/SidebarContentEdit.tsx
+++ b/src/components/sideBarContentEdit/SidebarContentEdit.tsx
@@ -179,7 +179,7 @@ const SidebarContentEdit = ({
           </Text>
           <OnlySelectField
             name="speakers"
-            editedData={sideBarData.list.speakers}
+            editedData={sideBarData.list.speakers || []}
             updateData={updateSpeaker}
             autoCompleteList={selectableListData?.speakers ?? []}
             userCanAddToList
@@ -206,7 +206,7 @@ const SidebarContentEdit = ({
           </Text>
           <SingleSelectField
             name="category"
-            editedData={sideBarData.list.categories}
+            editedData={sideBarData.list.categories || []}
             updateData={updateCategories}
             autoCompleteList={selectableListData?.categories ?? []}
           />
@@ -228,7 +228,7 @@ const SidebarContentEdit = ({
           </Flex>
           <OnlySelectField
             name="tags"
-            editedData={sideBarData.list.tags}
+            editedData={sideBarData.list.tags || []}
             updateData={updateTags}
             autoCompleteList={selectableListData?.tags ?? []}
           />


### PR DESCRIPTION
This solves an issue where if we have a transcript with no defined `categories` metadata field, the application breaks.